### PR TITLE
Replace skill progress bars with list

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -75,8 +75,7 @@
     .chip{padding:6px 10px;border:1px solid var(--ink);border-radius:999px;font-size:13px}
     .skills{display:flex;gap:8px;flex-wrap:wrap}
 
-    .progress{height:9px;background:#efe7dc;border-radius:99px;position:relative;overflow:hidden;border:1px solid var(--ring)}
-    .progress > span{position:absolute;height:100%;left:0;top:0;background:var(--ink)}
+    .skill-list{margin:0;padding-left:20px;display:flex;flex-direction:column;gap:6px}
 
     .timeline{position:relative}
     .timeline:before{content:"";position:absolute;left:28px;top:0;bottom:0;width:2px;background:var(--ring)}
@@ -229,14 +228,11 @@
         <!-- Skills -->
         <article class="card hover-raise">
           <h2>Skills</h2>
-          <div>
-            <p>Inventory Management</p>
-            <div class="progress" aria-label="Inventory Management"><span style="width:85%"></span></div>
-            <p>Baking</p>
-            <div class="progress"><span style="width:75%"></span></div>
-            <p>Customer Demos</p>
-            <div class="progress"><span style="width:65%"></span></div>
-          </div>
+          <ul class="skill-list">
+            <li>Inventory Management</li>
+            <li>Baking</li>
+            <li>Customer Demos</li>
+          </ul>
         </article>
 
         <!-- Languages -->


### PR DESCRIPTION
## Summary
- replace the skills progress bars with a simple list presentation
- add lightweight styling so the new list sits neatly in the sidebar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d15fd4b083309532030d54684ce8