### PR TITLE
Replace contact form with direct email link

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -254,14 +254,10 @@
         <!-- Contact -->
         <article class="card hover-raise" id="contact">
           <h2>Contact</h2>
-          <form id="contact-form" class="mix">
-            <input aria-label="Your name" required name="name" placeholder="Name" style="padding:10px;border-radius:12px;border:1px solid var(--ring);flex:1;min-width:180px" />
-            <input aria-label="Your email" required type="email" name="email" placeholder="Email" style="padding:10px;border-radius:12px;border:1px solid var(--ring);flex:1;min-width:180px" />
-            <textarea aria-label="Your message" required name="message" placeholder="Message" rows="4" style="padding:10px;border-radius:12px;border:1px solid var(--ring);flex-basis:100%"></textarea>
-            <button class="cta" id="send-btn" style="cursor:pointer">Send</button>
-            <a id="mailto-fallback" class="pill" href="mailto:soushia@outlook.com?subject=Hello&body=Hi!" style="text-decoration:none">or email me</a>
-            <span id="send-status" class="meta"></span>
-          </form>
+          <p>
+            Don't hesitate to email me at
+            <a class="pill" href="mailto:soushia@outlook.com">soushia@outlook.com</a>.
+          </p>
         </article>
 
         <!-- Quick Links -->
@@ -351,34 +347,6 @@
       }
       visitorsEl.textContent = visitorTotal;
     }
-
-    // Contact form (graceful email fallback)
-    $('#contact-form').addEventListener('submit', (event) => {
-      event.preventDefault();
-      const form = event.currentTarget;
-      const status = $('#send-status');
-      const btn = $('#send-btn');
-      status.textContent = 'Preparing email…';
-      btn.disabled = true;
-      const payload = Object.fromEntries(new FormData(form).entries());
-      const emailBody = [
-        'Hi Soushia!',
-        '',
-        `Name: ${payload.name}`,
-        `Email: ${payload.email}`,
-        '',
-        payload.message
-      ].join('\n');
-      const params = new URLSearchParams({
-        subject: 'Hello from your site',
-        body: emailBody
-      });
-      $('#mailto-fallback').href = `mailto:soushia@outlook.com?${params.toString()}`;
-      setTimeout(() => {
-        status.textContent = 'Please use the email link to get in touch →';
-        btn.disabled = false;
-      }, 300);
-    });
 
     // Projects (static data inlined for single-file build)
     const projects = [


### PR DESCRIPTION
## Summary
- remove the interactive contact form from the contact card
- add copy inviting visitors to email soushia@outlook.com directly
- delete the JavaScript handler that previously powered the contact form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d38d8bc48330b25483e71543b5cb