### PR TITLE
Remove pill styling from contact email link

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -251,7 +251,7 @@
           <h2>Contact</h2>
           <p>
             Don't hesitate to email me at
-            <a class="pill" href="mailto:soushia@outlook.com">soushia@outlook.com</a>.
+            <a href="mailto:soushia@outlook.com">soushia@outlook.com</a>.
           </p>
         </article>
 


### PR DESCRIPTION
## Summary
- remove the pill class from the contact email anchor so it displays without the rounded styling

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e2d9dae9088330a946722aaa7520da