### PR TITLE
Remove endorsements interaction

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -262,8 +262,6 @@
             <a class="pill" href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
             <a class="pill" href="https://www.linkedin.com/in/soushia" target="_blank" rel="noopener">LinkedIn</a>
             <a class="pill" href="#projects">Portfolio</a>
-            <button class="pill" id="endorse-btn" title="A fun micro‑interaction">+ Endorse</button>
-            <span class="pill" id="endorse-count">0 endorsements</span>
           </div>
         </article>
       </aside>
@@ -313,20 +311,6 @@
     // Year
     $('#year').textContent = new Date().getFullYear();
 
-    // Endorsements (fully client-side)
-    const ENDORSE_KEY = 'sdm-endorse-count';
-    const endorseCountEl = $('#endorse-count');
-    let endorseCount = readNumber(ENDORSE_KEY, 0);
-    const renderEndorsements = () => {
-      endorseCountEl.textContent = `${endorseCount} endorsement${endorseCount === 1 ? '' : 's'}`;
-    };
-    renderEndorsements();
-    $('#endorse-btn').addEventListener('click', () => {
-      endorseCount += 1;
-      writeNumber(ENDORSE_KEY, endorseCount);
-      renderEndorsements();
-    });
-
     // Visitor count (tracked per unique browser)
     const VISITOR_TOTAL_KEY = 'sdm-visitor-total';
     const VISITOR_SEEN_KEY = 'sdm-visitor-seen';
@@ -365,7 +349,7 @@
   <!--
     ========================= SINGLE-FILE NOTES =========================
     This build inlines all styling and behaviour so it can be hosted as a
-    standalone HTML document. Visitor and endorsement counters rely on
+    standalone HTML document. Visitor counter relies on
     localStorage; if a browser blocks storage the UI will still function
     without persistence. The contact button now prepares a pre-filled email
     draft instead of calling a backend service.


### PR DESCRIPTION
## Summary
- remove the endorsements button and counter from the Links card
- delete the client-side endorsement tracking logic and update documentation comment

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2d9f41074833095480fb502bbed06