### PR TITLE
Reorder skills card to appear after languages

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -220,6 +220,13 @@
 
       <!-- ========================= RIGHT COLUMN ========================= -->
       <aside class="right">
+        <!-- Languages -->
+        <article class="card hover-raise">
+          <h2>Languages</h2>
+          <p>Persian — Native/Bilingual</p>
+          <p>English — Native/Bilingual</p>
+        </article>
+
         <!-- Skills -->
         <article class="card hover-raise">
           <h2>Skills</h2>
@@ -228,13 +235,6 @@
             <li>Baking</li>
             <li>Customer Demos</li>
           </ul>
-        </article>
-
-        <!-- Languages -->
-        <article class="card hover-raise">
-          <h2>Languages</h2>
-          <p>Persian — Native/Bilingual</p>
-          <p>English — Native/Bilingual</p>
         </article>
 
         <!-- Education -->


### PR DESCRIPTION
## Summary
- move the skills card below the languages card in the right column of the profile page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2da4234fc83308574a1b70705f964