### PR TITLE
Enhance navigation focus fade effect

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -98,9 +98,24 @@
     .hover-raise:hover{transform: translateY(-2px); box-shadow: 0 14px 30px rgba(0,0,0,.10), 0 4px 10px rgba(0,0,0,.08)}
 
     /* navigation focus fading */
-    .fadeable{transition: opacity .35s ease}
-    body.nav-focus .fadeable{opacity:.18}
-    body.nav-focus .fadeable.is-highlight{opacity:1}
+    .fadeable{transition: opacity .35s ease, transform .45s ease, box-shadow .45s ease; transform-origin:center top; will-change:opacity, transform}
+    body::before{
+      content:"";
+      position:fixed;
+      inset:0;
+      background:rgba(11,11,11,.45);
+      opacity:0;
+      pointer-events:none;
+      transition:opacity .35s ease;
+      z-index:40;
+    }
+    body.nav-focus::before{opacity:.5}
+    body.nav-focus .fadeable{opacity:.16}
+    body.nav-focus .fadeable.is-highlight{opacity:1; position:relative; z-index:60; transform:scale(1.02); box-shadow:0 22px 55px rgba(0,0,0,.22)}
+    body.nav-focus header.site{box-shadow:0 18px 42px rgba(0,0,0,.12)}
+    header nav a{transition:background .3s ease, color .3s ease, transform .3s ease, opacity .3s ease}
+    body.nav-focus header nav a{opacity:.55}
+    body.nav-focus header nav a.is-active{opacity:1; transform:scale(1.08)}
   </style>
 </head>
 <body>
@@ -328,16 +343,18 @@
     const VISITOR_TOTAL_KEY = 'sdm-visitor-total';
     const VISITOR_SEEN_KEY = 'sdm-visitor-seen';
     const visitorsEl = $('#visitors');
-    let visitorTotal = readNumber(VISITOR_TOTAL_KEY, 0);
-    if (!storage) {
-      visitorsEl.textContent = 'offline';
-    } else {
-      if (!storage.getItem(VISITOR_SEEN_KEY)) {
-        visitorTotal += 1;
-        writeNumber(VISITOR_TOTAL_KEY, visitorTotal);
-        storage.setItem(VISITOR_SEEN_KEY, '1');
+    if (visitorsEl) {
+      let visitorTotal = readNumber(VISITOR_TOTAL_KEY, 0);
+      if (!storage) {
+        visitorsEl.textContent = 'offline';
+      } else {
+        if (!storage.getItem(VISITOR_SEEN_KEY)) {
+          visitorTotal += 1;
+          writeNumber(VISITOR_TOTAL_KEY, visitorTotal);
+          storage.setItem(VISITOR_SEEN_KEY, '1');
+        }
+        visitorsEl.textContent = visitorTotal;
       }
-      visitorsEl.textContent = visitorTotal;
     }
 
     // Projects (static data inlined for single-file build)


### PR DESCRIPTION
## Summary
- add a page-wide dimming overlay when navigation focus mode is active so content outside the target section fades
- enlarge the highlighted section and active navigation link for clearer focus while the menu is used
- harden the visitor counter script against missing DOM nodes

## Testing
- No automated tests were run (HTML/CSS/JS change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2dbce3be88330b825ed4dc7d23e75