### PR TITLE
Improve navigation focus behaviour

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -106,8 +106,7 @@
 
     /* navigation focus fading */
     .fadeable{transition: opacity .35s ease, transform .45s ease, box-shadow .45s ease; transform-origin:center top; will-change:opacity, transform}
-    body::before{
-      content:"";
+    .nav-backdrop{
       position:fixed;
       inset:0;
       background:rgba(11,11,11,.45);
@@ -116,7 +115,10 @@
       transition:opacity .35s ease;
       z-index:40;
     }
-    body.nav-focus::before{opacity:.5}
+    body.nav-focus .nav-backdrop{
+      opacity:.5;
+      pointer-events:auto;
+    }
     body.nav-focus .fadeable{opacity:.16}
     body.nav-focus .fadeable.is-highlight{opacity:1; position:relative; z-index:60; transform:scale(1.02); box-shadow:0 22px 55px rgba(0,0,0,.22)}
     body.nav-focus header.site{box-shadow:0 18px 42px rgba(0,0,0,.12)}
@@ -127,6 +129,8 @@
 </head>
 <body>
   <!-- ========================= HEADER ========================= -->
+  <div class="nav-backdrop" data-nav-backdrop aria-hidden="true"></div>
+
   <header class="site">
     <div class="site-inner container">
       <a class="brand" href="#top">
@@ -385,6 +389,20 @@
     // Menu-driven focus fade
     const fadeables = $$('[data-section]');
     const navLinks = $$('header nav a');
+    const navBackdrop = $('[data-nav-backdrop]');
+    const reduceMotionMedia = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : { matches: false };
+    const getScrollBehavior = () => (reduceMotionMedia.matches ? 'auto' : 'smooth');
+    const centerSection = (section) => {
+      if (!section || typeof section.scrollIntoView !== 'function') return;
+      const behavior = getScrollBehavior();
+      try {
+        section.scrollIntoView({ behavior, block: 'center', inline: 'nearest' });
+      } catch (error) {
+        section.scrollIntoView();
+      }
+    };
     const clearHighlight = () => {
       fadeables.forEach((el) => el.classList.remove('is-highlight'));
     };
@@ -409,7 +427,7 @@
       });
       return true;
     };
-    const highlightSection = (section) => {
+    const highlightSection = (section, { scroll = false } = {}) => {
       if (!section) return;
       document.body.classList.add('nav-focus');
       clearHighlight();
@@ -418,12 +436,15 @@
       if (section.id) {
         setActiveNav(`#${section.id}`);
       }
+      if (scroll) {
+        centerSection(section);
+      }
     };
-    const activateByHash = (hash) => {
+    const activateByHash = (hash, options = {}) => {
       if (!hash) return;
       const target = document.querySelector(hash);
       if (!target || !fadeables.includes(target)) return;
-      highlightSection(target);
+      highlightSection(target, options);
     };
 
     const schedule = window.requestAnimationFrame
@@ -434,16 +455,17 @@
       link.addEventListener('click', () => {
         const { hash } = link;
         if (!hash) return;
-        schedule(() => activateByHash(hash));
+        const shouldScrollImmediately = window.location.hash === hash;
+        schedule(() => activateByHash(hash, { scroll: shouldScrollImmediately }));
       });
     });
 
     window.addEventListener('hashchange', () => {
-      activateByHash(window.location.hash);
+      activateByHash(window.location.hash, { scroll: true });
     });
 
     if (window.location.hash) {
-      activateByHash(window.location.hash);
+      activateByHash(window.location.hash, { scroll: true });
     }
 
     document.addEventListener('keydown', (event) => {
@@ -460,6 +482,10 @@
     ['scroll', 'wheel', 'touchmove'].forEach((eventName) => {
       window.addEventListener(eventName, maybeExitOnScroll, { passive: true });
     });
+
+    if (navBackdrop) {
+      navBackdrop.addEventListener('click', exitNavFocus);
+    }
 
     if ('IntersectionObserver' in window) {
       const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
## Summary
- replace the pseudo-element overlay with a clickable backdrop so the navigation focus state can be dismissed by tapping the faded background
- center targeted sections when navigating via header links while respecting reduced-motion preferences
- keep the navigation highlight responsive by reusing the existing fade/highlight logic and allowing hash-based navigation to trigger the enhancements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2decfbf50833095d808e162532c67