### PR TITLE
Remove hero photo from landing page

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -209,25 +209,9 @@
     .hero {
       padding: clamp(3rem, 8vw, 5rem) 0 4rem;
       display: grid;
-      grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+      grid-template-columns: minmax(0, 1fr);
       gap: clamp(2rem, 6vw, 4rem);
       align-items: center;
-    }
-
-    .hero-media {
-      position: relative;
-      border-radius: var(--radius-lg);
-      overflow: hidden;
-      background: radial-gradient(circle at 30% 20%, rgba(79, 124, 172, 0.18), transparent 60%), var(--surface);
-      padding: 18px;
-      box-shadow: var(--shadow-lg);
-    }
-
-    .hero-media img {
-      border-radius: var(--radius-md);
-      height: 100%;
-      width: 100%;
-      object-fit: cover;
     }
 
     .hero-text {
@@ -292,12 +276,7 @@
 
     @media (max-width: 960px) {
       .hero {
-        grid-template-columns: 1fr;
-      }
-      .hero-media {
-        order: -1;
-        width: min(400px, 70vw);
-        margin: 0 auto;
+        padding: clamp(2.5rem, 9vw, 4rem) 0 3.5rem;
       }
     }
 
@@ -577,9 +556,6 @@
             </div>
           </div>
         </div>
-      </div>
-      <div class="hero-media">
-        <img src="https://picsum.photos/seed/portrait-soushia/640/760" alt="Soushia smiling and working on a laptop" />
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- remove the hero portrait image from the about section so the page no longer displays a photo
- update the hero layout spacing to center the remaining content and maintain responsive padding

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e359dc44d083309f03e9a21bcb78b1