### PR TITLE
Adjust spacing between profile categories

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -301,9 +301,16 @@
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius-md);
-      padding: clamp(1.6rem, 2.6vw, 2rem);
+      padding: clamp(1.9rem, 3vw, 2.4rem);
       box-shadow: var(--shadow-md);
       transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+    }
+
+    .left,
+    .right {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(1.6rem, 4vw, 2.4rem);
     }
 
     .card:hover {


### PR DESCRIPTION
## Summary
- increase the padding applied to profile cards for more comfortable breathing room
- add column gaps between the left and right groupings so categories are spaced further apart

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35aad7e448330847bcfdb945a337f