### PR TITLE
Align timeline markers with experience line

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -387,7 +387,7 @@
     .timeline-item::before {
       content: "";
       position: absolute;
-      left: -3px;
+      left: -15px;
       top: 8px;
       width: 12px;
       height: 12px;


### PR DESCRIPTION
## Summary
- adjust the timeline marker offset so the toggle aligns with the vertical line in the Experience section

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e35c9833388330bf94c8034f04be5a