### PR TITLE
Fix hero stat tiles markup for correct pill rendering

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -537,30 +537,32 @@
           numbers with people-first thinking. Whether it’s streamlining processes, tracking performance, or supporting
           collaboration, I enjoy building structures that help teams thrive while driving sustainable results.
         </p>
-        <div class="meta-line">
-          <span>Laguna Niguel, CA</span>
-          <span>Open to internships &amp; early-career roles</span>
-        </div>
-        <div class="hero-actions">
-          <a class="btn primary" href="mailto:soushia@outlook.com">Let’s collaborate</a>
-          <a class="btn secondary" href="#projects">View highlighted work</a>
-        </div>
-        <div class="stat-tiles" aria-label="Snapshot achievements">
-          <div class="stat">
-            <div>
-              <strong>3+</strong>
-              <span>Years in customer-facing roles</span>
-            </div>
-          <div class="stat">
-            <div>
-              <strong>3+</strong>
-              <span>Years investing in the stock market</span>
-            </div>
+          <div class="meta-line">
+            <span>Laguna Niguel, CA</span>
+            <span>Open to internships &amp; early-career roles</span>
           </div>
-          <div class="stat">
-            <div>
-              <strong>2027</strong>
-              <span>Expected business A.S. graduate</span>
+          <div class="hero-actions">
+            <a class="btn primary" href="mailto:soushia@outlook.com">Let’s collaborate</a>
+            <a class="btn secondary" href="#projects">View highlighted work</a>
+          </div>
+          <div class="stat-tiles" aria-label="Snapshot achievements">
+            <div class="stat">
+              <div>
+                <strong>3+</strong>
+                <span>Years in customer-facing roles</span>
+              </div>
+            </div>
+            <div class="stat">
+              <div>
+                <strong>3+</strong>
+                <span>Years investing in the stock market</span>
+              </div>
+            </div>
+            <div class="stat">
+              <div>
+                <strong>2027</strong>
+                <span>Expected business A.S. graduate</span>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- correct the hero statistic tiles markup by adding the missing wrappers
- ensure each stat pill has the proper closing tags for consistent styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3644c1a588330802503b8b6bff18e