### PR TITLE
Remove LinkedIn and GitHub contact links

### DIFF
--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -681,9 +681,6 @@
         <article class="card" id="contact" data-section>
           <h2>Contact</h2>
           <p>Email: <a href="mailto:soushia@outlook.com">soushia@outlook.com</a></p>
-          <p>LinkedIn: <a href="https://www.linkedin.com/in/soushia" target="_blank" rel="noopener">/in/soushia</a></p>
-          <p>LinkedIn: <a href="https://www.linkedin.com/in/soushia" target="_blank" rel="noopener"><strong>LinkedIn</strong></a></p>
-          <p>GitHub: <a href="https://github.com/" target="_blank" rel="noopener">github.com</a></p>
           <p>
             Interested in collaborations or internships? Send a note.
           </p>


### PR DESCRIPTION
## Summary
- remove the LinkedIn and GitHub entries from the contact section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e36641401083309d92bc698fe6cb4e