### PR TITLE
Create centered contact page and update navigation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contact — Soushia DooghaieMoghadam</title>
+    <meta name="description" content="Contact information for Soushia DooghaieMoghadam." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f5f6f8;
+        --surface: #ffffff;
+        --text: #1f2933;
+        --muted: #52606d;
+        --accent: #4f7cac;
+        --border: rgba(148, 163, 184, 0.35);
+        --radius: 28px;
+        --shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+        font-family: "Outfit", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      *, *::before, *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px;
+        background: radial-gradient(circle at 20% -10%, rgba(79, 124, 172, 0.18), transparent 55%),
+          radial-gradient(circle at 80% 10%, rgba(120, 141, 169, 0.18), transparent 45%),
+          var(--bg);
+        color: var(--text);
+        line-height: 1.6;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .card {
+        width: min(520px, 100%);
+        background: var(--surface);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: clamp(24px, 6vw, 48px);
+        text-align: center;
+        border: 1px solid var(--border);
+      }
+
+      h1 {
+        margin-top: 0;
+        font-size: clamp(2rem, 5vw, 2.6rem);
+        letter-spacing: -0.01em;
+      }
+
+      p {
+        margin: 0 0 1.2rem;
+      }
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 16px;
+      }
+
+      .contact-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        border-radius: 999px;
+        padding: 12px 20px;
+        border: 1px solid var(--border);
+        background: rgba(79, 124, 172, 0.08);
+        color: var(--text);
+        font-weight: 600;
+        transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1),
+          background-color 220ms cubic-bezier(0.4, 0, 0.2, 1);
+      }
+
+      .contact-link:focus-visible,
+      .contact-link:hover {
+        transform: translateY(-2px);
+        background: rgba(79, 124, 172, 0.14);
+        outline: none;
+      }
+
+      .contact-link span {
+        font-size: 1rem;
+      }
+
+      .contact-link svg {
+        width: 24px;
+        height: 24px;
+        flex-shrink: 0;
+      }
+
+      .hint {
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      .back-link {
+        display: inline-block;
+        margin-top: 2rem;
+        color: var(--accent);
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card" id="contact" tabindex="-1">
+      <h1>Connect with Me</h1>
+      <p class="hint">Select a preferred method below to start the conversation.</p>
+      <ul aria-label="Contact methods">
+        <li>
+          <a class="contact-link" href="mailto:soushia@outlook.com">
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="3" y="5" width="18" height="14" rx="2" ry="2" />
+              <path d="m3 7 9 6 9-6" />
+            </svg>
+            <span>Email soushia@outlook.com</span>
+          </a>
+        </li>
+        <li>
+          <a
+            class="contact-link"
+            href="https://www.linkedin.com/in/soushia-dooghaie-moghadam"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+            >
+              <rect x="2" y="2" width="20" height="20" rx="4" fill="#0a66c2" />
+              <path d="M7.25 10.25h1.75V17H7.25z" fill="white" />
+              <path d="M8.13 7a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" fill="white" />
+              <path
+                d="M11.75 10.17h1.68v.94h.03c.23-.43.8-1.1 1.97-1.1 2.11 0 2.5 1.32 2.5 3.04V17h-1.82v-3.29c0-.79-.02-1.81-1.1-1.81-1.1 0-1.27.86-1.27 1.75V17h-1.82Z"
+                fill="white"
+              />
+            </svg>
+            <span>Message on LinkedIn</span>
+          </a>
+        </li>
+      </ul>
+      <a class="back-link" href="linked_in_style_personal_site_git_hub_friendly.html">← Back to homepage</a>
+    </main>
+    <script>
+      window.addEventListener('load', () => {
+        document.getElementById('contact')?.focus();
+      });
+    </script>
+  </body>
+</html>

--- a/linked_in_style_personal_site_git_hub_friendly.html
+++ b/linked_in_style_personal_site_git_hub_friendly.html
@@ -568,7 +568,7 @@
         <a href="#experience">Experience</a>
         <a href="#projects">Projects</a>
         <a href="#education">Education</a>
-        <a href="#contact" class="cta">Contact</a>
+        <a href="contact.html" class="cta">Contact</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- add a standalone contact page that centers the contact methods and includes accessible focus management
- update the header contact button to open the new page
- update the contact page heading to "Connect with Me" and replace emoji icons with branded app logos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3693e681083309787b65646d1a2d4